### PR TITLE
Update legacy code (deprecated function call)

### DIFF
--- a/login_bloc/lib/src/blocs/provider.dart
+++ b/login_bloc/lib/src/blocs/provider.dart
@@ -9,6 +9,6 @@ class Provider extends InheritedWidget {
   bool updateShouldNotify(_) => true;
 
   static Bloc of(BuildContext context) {
-    return (context.inheritFromWidgetOfExactType(Provider) as Provider).bloc;
+    return (context.dependOnInheritedWidgetOfExactType<Provider>()).bloc;
   }
 }


### PR DESCRIPTION
'inheritFromWidgetOfExactType' is deprecated and shouldn't be used. Use dependOnInheritedWidgetOfExactType instead. This feature was deprecated after v1.12.1..