### PR TITLE
Disable raise button by default

### DIFF
--- a/login_bloc/lib/src/screens/login_screen.dart
+++ b/login_bloc/lib/src/screens/login_screen.dart
@@ -59,7 +59,7 @@ class LoginScreen extends StatelessWidget {
         return RaisedButton(
           child: Text('Login'),
           color: Colors.blue,
-          onPressed: snapshot.hasData ? bloc.submit : null,
+          onPressed: snapshot.hasData || snapshot.data == null ? bloc.submit : null,
         );
       },
     );


### PR DESCRIPTION
Small improvement.
Disable raise button by default while widget initialization.