### PR TITLE
Stack. Replace overflow by clipBehavior

### DIFF
--- a/animation/lib/src/screens/home.dart
+++ b/animation/lib/src/screens/home.dart
@@ -67,7 +67,7 @@ class HomeState extends State<Home> with TickerProviderStateMixin {
       body: GestureDetector(
         child: Center(
           child: Stack(
-            overflow: Overflow.visible,
+            clipBehavior: Clip.none,
             children: [
               buildCatAnimation(),
               buildBox(),


### PR DESCRIPTION
Stack widget.
'overflow' is deprecated and shouldn't be used. Use clipBehavior instead. See the migration guide in flutter.dev/go/clip-behavior. This feature was deprecated after v1.22.0-12.0.pre..

-   overflow: Overflow.visible,
+  clipBehavior: Clip.none,