### PR TITLE
Update legacy code (deprecated function call)

### DIFF
--- a/news/lib/src/blocs/stories_provider.dart
+++ b/news/lib/src/blocs/stories_provider.dart
@@ -12,8 +12,6 @@ class StoriesProvider extends InheritedWidget {
   bool updateShouldNotify(_) => true;
 
   static StoriesBloc of(BuildContext context) {
-    return (context.inheritFromWidgetOfExactType(StoriesProvider)
-            as StoriesProvider)
-        .bloc;
+    return (context.dependOnInheritedWidgetOfExactType<StoriesProvider>()).bloc;
   }
 }


### PR DESCRIPTION
'inheritFromWidgetOfExactType' is deprecated and shouldn't be used. Use dependOnInheritedWidgetOfExactType instead. This feature was deprecated after v1.12.1..