### PR TITLE
Update legacy code (deprecated function call)

### DIFF
--- a/news/lib/src/blocs/comments_provider.dart
+++ b/news/lib/src/blocs/comments_provider.dart
@@ -12,8 +12,7 @@ class CommentsProvider extends InheritedWidget {
   bool updateShouldNotify(_) => true;
 
   static CommentsBloc of(BuildContext context) {
-    return (context.inheritFromWidgetOfExactType(CommentsProvider)
-            as CommentsProvider)
+    return (context.dependOnInheritedWidgetOfExactType<CommentsProvider>())
         .bloc;
   }
 }


### PR DESCRIPTION
'inheritFromWidgetOfExactType' is deprecated and shouldn't be used. Use dependOnInheritedWidgetOfExactType instead. This feature was deprecated after v1.12.1..